### PR TITLE
Lean chan

### DIFF
--- a/sorter.go
+++ b/sorter.go
@@ -9,41 +9,41 @@ var lst []int
 
 func Sort(input []int, dir bool) {
 	lst = input
-	sentinel := make(chan int)
+	sentinel := make(chan struct{})
 	go bitonicSort(0, len(lst), dir, sentinel)
 	<-sentinel
 }
 
-func bitonicSort(lo int, n int, dir bool, sentinel chan int) {
+func bitonicSort(lo int, n int, dir bool, sentinel chan struct{}) {
 	if n > 1 {
 		m := n / 2
-		c1 := make(chan int)
-		c2 := make(chan int)
+		c1 := make(chan struct{})
+		c2 := make(chan struct{})
 		go bitonicSort(lo, m, SORT_ASC, c1)
 		go bitonicSort(lo+m, m, SORT_DESC, c2)
 		<-c1
 		<-c2
 		bitonicMerge(lo, n, dir, sentinel)
 	} else {
-		sentinel <- 1
+		sentinel <- struct{}{}
 	}
 }
 
-func bitonicMerge(lo int, n int, dir bool, sentinel chan int) {
+func bitonicMerge(lo int, n int, dir bool, sentinel chan struct{}) {
 	if n > 1 {
 		m := n / 2
 		for i := lo; i < lo+m; i++ {
 			compareAndSwap(i, i+m, dir)
 		}
-		c1 := make(chan int)
-		c2 := make(chan int)
+		c1 := make(chan struct{})
+		c2 := make(chan struct{})
 		go bitonicMerge(lo, m, dir, c1)
 		go bitonicMerge(lo+m, m, dir, c2)
 		<-c1
 		<-c2
 	}
 
-	sentinel <- 1
+	sentinel <- struct{}{}
 }
 
 func compareAndSwap(i int, j int, dir bool) {

--- a/sorter_test.go
+++ b/sorter_test.go
@@ -1,11 +1,12 @@
 package bitonic_test
 
 import (
-	"github.com/farazdagi/bitonic"
 	"math/rand"
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/farazdagi/bitonic"
 )
 
 const SAMPLE_SIZE = 1 << 16


### PR DESCRIPTION
This CL uses `chan struct{}` as the type for the sentinel channel.
This is more Go-idiomatic for a sentinel channel (where only the fact that
something transited thru the channel matters, not its value) and, as a value
of type `struct{}` does not use any memory, it should reduce the memory footprint.
